### PR TITLE
Use pkg_resources to keep the package zip-safe

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.rst
 include _dump.pl
-include src/text_unicode/data.bin
 include test_unidecode.py

--- a/src/text_unidecode/__init__.py
+++ b/src/text_unidecode/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import os
+from pkg_resources import resource_filename
 
-_data_path = os.path.join(os.path.dirname(__file__), 'data.bin')
+_data_path = resource_filename(__name__, 'data.bin')
 with open(_data_path, 'rb') as f:
     _replaces = f.read().decode('utf8').split('\x00')
 


### PR DESCRIPTION
This resolves a bug in the packaging of this package, which I encountered after _[Faker](https://github.com/joke2k/faker)_ started depending on it recently.

When _text_unidecode_ is installed manually from a source distribution, in a `PYTHONDONTWRITEBYTECODE=1` environment, it ends up in the shape of a **zipfile egg** in site-packages, as it is not marked **zip-unsafe**. This means that importing it will result in an error, because [this instruction](https://github.com/kmike/text-unidecode/blob/1.0/src/text_unidecode/__init__.py#L6) will try to open a file in what it thinks is a directory, when it is actually a zipfile. The package could be marked as zip-unsafe, but there is an even better way to solve the problem:

```
from pkg_resources import resource_filename
_data_path = resource_filename(__name__, 'data.bin')
```

_pkg_resources_ (which is part of setuptools) will take care of unzipping and caching the data file, returning a valid filename which can be consumed.

This changeset also removes two redundant lines from `Manifest.in`:
- `README.rst` as it is part of the [default README files](https://github.com/pypa/setuptools/blob/master/setuptools/command/sdist.py#L40)
- `src/text_unicode/data.bin` because it refers to an non-existent file (the package name has a typo in it), but would be redundant anyway as `data.bin` is specified as part of `package_data` in `setup.py`

EDIT: Corrected code quote as I pasted the wrong line.