### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python: 3.4
 sudo: false
 env:
@@ -12,6 +13,3 @@ env:
 install:
  - pip install -U tox
 script: tox
-cache:
-  directories:
-    - $HOME/.cache/pip


### PR DESCRIPTION
Can speed up builds and reduce load on PyPI servers.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache