### PR TITLE
Use pkgutil instead of pkg_resources.

### DIFF
--- a/src/text_unidecode/__init__.py
+++ b/src/text_unidecode/__init__.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import os
-from pkg_resources import resource_filename
+import pkgutil
 
-_data_path = resource_filename(__name__, 'data.bin')
-with open(_data_path, 'rb') as f:
-    _replaces = f.read().decode('utf8').split('\x00')
-
+_replaces = pkgutil.get_data(__name__, 'data.bin').decode('utf8').split('\x00')
 
 def unidecode(txt):
     chars = []


### PR DESCRIPTION
pkgutil is part of the standard library. So, by using pkgutil.get_data, we can avoid a runtime dependency on setuptools.